### PR TITLE
Remove extra $ from sample command

### DIFF
--- a/.github/workflows/check-illumos.sh
+++ b/.github/workflows/check-illumos.sh
@@ -74,7 +74,7 @@ echo -e "# Export the sha256sum for verification." >> ${README};
 echo -e "\$ export OXIDE_CLI_SHA256=\"`cat ${BUILDDIR}/${NAME}.sha256 | awk '{print $1}'`\"\n\n" >> ${README};
 echo -e "# Download and check the sha256sum." >> ${README};
 echo -e "\$ curl -fSL \"https://dl.oxide.computer/releases/cli/v${VERSION}/${NAME}\" -o \"/usr/local/bin/oxide\" \\" >> ${README};
-echo -e "\t&& echo \"\$${OXIDE_CLI_SHA256}  /usr/local/bin/oxide\" | sha256sum -c - \\" >> ${README};
+echo -e "\t&& echo \"\${OXIDE_CLI_SHA256}  /usr/local/bin/oxide\" | sha256sum -c - \\" >> ${README};
 echo -e "\t&& chmod a+x \"/usr/local/bin/oxide\"\n\n" >> ${README};
 echo -e "\$ echo \"oxide cli installed!\"\n" >> ${README};
 echo -e "# Run it!" >> ${README};


### PR DESCRIPTION
The generated release notes (for illumos) was missing the `${OXIDE_CLI_SHA256}` from the sample command:

```
# Download and check the sha256sum.
$ curl -fSL "https://dl.oxide.computer/releases/cli/v0.2.2/oxide-x86_64-unknown-illumos" -o "/usr/local/bin/oxide" \
	&& echo "$  /usr/local/bin/oxide" | sha256sum -c - \
	&& chmod a+x "/usr/local/bin/oxide"
```

Just a `$` was appearing.