### PR TITLE
ssh-key commands

### DIFF
--- a/src/cmd_ssh_key.rs
+++ b/src/cmd_ssh_key.rs
@@ -43,7 +43,7 @@ pub struct CmdSSHKeyAdd {
     #[clap(long, short)]
     pub generate: bool,
 
-    /// SSH key type to generate.
+    /// SSH key type to use or generate.
     #[clap(long = "type", short = 't', default_value_t)]
     pub key_type: SSHKeyAlgorithm,
 


### PR DESCRIPTION
Fixes #34. Can read public keys from the default file locations (`~/.ssh/id_*.pub`) and GitHub. All commands (`add`, `list`, `delete`, `sync-from-github`) are working.

Key generation is not currently working; see #200.