### PR TITLE
Fix tests after omicron version upgrade

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -771,7 +771,7 @@ date:"#
                 "--ncpus".to_string(),
                 "1".to_string(),
                 "--memory".to_string(),
-                "1024".to_string(),
+                "1073741824".to_string(),
                 "--hostname".to_string(),
                 "my-db".to_string(),
                 "--description".to_string(),
@@ -796,7 +796,7 @@ date:"#
                 "--ncpus".to_string(),
                 "1".to_string(),
                 "--memory".to_string(),
-                "1024".to_string(),
+                "1073741824".to_string(),
                 "--hostname".to_string(),
                 "my-app".to_string(),
                 "--description".to_string(),
@@ -819,7 +819,7 @@ date:"#
                 "development".to_string(),
                 "my-app".to_string(),
             ],
-            want_out: r#"memory                 | 1024"#
+            want_out: r#"memory                 | 1073741824"#
                 .to_string(),
             want_err: "".to_string(),
             want_code: 0,
@@ -977,7 +977,7 @@ date:"#
                 /*"--snapshot".to_string(),
                 "42583766-9318-4339-A2A2-EE286F0F5B26".to_string(),*/
                 "--size".to_string(),
-                "1024".to_string(),
+                "1073741824".to_string(),
                 "-D".to_string(),
                 "My new disk".to_string(),
             ],
@@ -1002,7 +1002,7 @@ date:"#
                 /*"--snapshot".to_string(),
                 "42583766-9318-4339-A2A2-EE286F0F5B26".to_string(),*/
                 "--size".to_string(),
-                "1024".to_string(),
+                "1073741824".to_string(),
                 "-D".to_string(),
                 "My second new disk".to_string(),
             ],
@@ -1065,9 +1065,9 @@ date:"#
                 "--project".to_string(),
                 "development".to_string(),
                 "new-disk".to_string(),
-                "my-db".to_string(),
+                "my-app".to_string(),
             ],
-            want_out: "✔ Attached disk new-disk to instance my-db in project maze-war/development".to_string(),
+            want_out: "✔ Attached disk new-disk to instance my-app in project maze-war/development".to_string(),
             want_err: "".to_string(),
             want_code: 0,
             ..Default::default()
@@ -1144,9 +1144,9 @@ date:"#
                 "--project".to_string(),
                 "development".to_string(),
                 "new-disk".to_string(),
-                "my-db".to_string(),
+                "my-app".to_string(),
             ],
-            want_out: "✔ Detached disk new-disk from instance my-db in project maze-war/development".to_string(),
+            want_out: "✔ Detached disk new-disk from instance my-app in project maze-war/development".to_string(),
             want_err: "".to_string(),
             want_code: 0,
             ..Default::default()


### PR DESCRIPTION
This PR fixes the tests that were passing as they were before the Omicron version upgrade

```console
$ cargo test
   Compiling oxide v0.2.5 (/Users/karcafv/src/oxide/cli)
    Finished test [unoptimized + debuginfo] target(s) in 19.99s
     Running unittests (target/debug/deps/oxide-01dbebe82bfd4153)

running 40 tests
test cmd_api::test::test_add_query_string ... ok
test cmd_auth::test::test_parse_host ... ok
test cmd_disk::test::test_cmd_disk ... ok
test cmd_generate::test::test_generate_man_pages_sub_subcommands ... ok
test cmd_config::test::test_cmd_config ... ok
test cmd_generate::test::test_generate_markdown_sub_subcommands ... ok
test cmd_instance::test::test_cmd_instance ... ok
test cmd_project::test::test_cmd_project ... ok
test cmd_alias::test::test_valid_command ... ok
test cmd_route::test::test_cmd_route ... ok
test cmd_router::test::test_cmd_router ... ok
test cmd_subnet::test::test_cmd_subnet ... ok
test cmd_vpc::test::test_cmd_vpc ... ok
test colors::test::test_env_color_forced ... ok
test config::test::test_default_config ... ok
test cmd_generate::test::test_generate_markdown ... ok
test config::test::test_file_config_set_no_host ... ok
test config::test::test_file_config_set_with_host ... ok
test config::test::test_parse_config ... ok
test config::test::test_parse_config_multiple_hosts ... ok
test config::test::test_validate_key ... ok
test config::test::test_expand_alias ... ok
test config::test::test_validate_value ... ok
test config_alias::test::test_aliases ... ok
test iostreams::test::test_force_terminal ... ok
test cmd_generate::test::test_generate_man_pages ... ok
test cmd_alias::test::test_cmd_alias ... ok
test ssh::test::test_ssh_key_generate_ecdsa ... ok
test ssh::test::test_ssh_key_generate_ed25519 ... ok
test cmd_completion::test::test_cmd_completion_get ... ok
test cmd_auth::test::test_cmd_auth ... ok
test update::test::test_get_exe_download_url ... ok
test update::test::test_update ... ok
test cmd_org::test::test_cmd_org ... ok
test colors::test::test_env_color_disabled ... ok
test context::test::test_context ... ok
test ssh::test::test_get_github_ssh_keys ... ok
test update::test::test_download_binary_to_temp_file ... ok
✔  Waiting for instance status to be `stopped`
✔  Waiting for instance status to be `running`
✔  Waiting for instance status to be `running`
✔  Waiting for instance status to be `stopped`
test tests::test_main ... FAILED
test update::test::test_check_for_update ... ok

failures:

---- tests::test_main stdout ----
thread 'tests::test_main' panicked at 'test create route ->
stdout: 
want: ✔ Created route my-route in maze-war/development

stderr: ✘ Oxide API internal error: unable to parse body: invalid type: map, expected a string at line 1 column 95
', src/tests.rs:1770:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    tests::test_main

test result: FAILED. 39 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 25.41s
```