### PR TITLE
Don't bomb out if we can't open the browser

### DIFF
--- a/src/cmd_auth.rs
+++ b/src/cmd_auth.rs
@@ -228,7 +228,7 @@ impl crate::cmd::Command for CmdAuthLogin {
                     details.verification_uri().to_string(),
                     details.user_code().secret().to_string()
                 )?;
-                ctx.browser(host, uri.secret())?;
+                let _ = ctx.browser(host, uri.secret());
             } else {
                 writeln!(
                     ctx.io.out,

--- a/src/cmd_auth.rs
+++ b/src/cmd_auth.rs
@@ -226,7 +226,7 @@ impl crate::cmd::Command for CmdAuthLogin {
                     "Opening {} in your browser.\n\
                      Please verify user code: {}\n",
                     uri.secret(),
-                    details.user_code().secret().to_string()
+                    details.user_code().secret()
                 )?;
                 let _ = ctx.browser(host, uri.secret());
             } else {
@@ -234,8 +234,8 @@ impl crate::cmd::Command for CmdAuthLogin {
                     ctx.io.out,
                     "Open this URL in your browser:\n{}\n\
                      And enter the code: {}\n",
-                    details.verification_uri().to_string(),
-                    details.user_code().secret().to_string()
+                    **details.verification_uri(),
+                    details.user_code().secret()
                 )?;
             }
 

--- a/src/cmd_auth.rs
+++ b/src/cmd_auth.rs
@@ -225,7 +225,7 @@ impl crate::cmd::Command for CmdAuthLogin {
                     ctx.io.out,
                     "Opening {} in your browser.\n\
                      Please verify user code: {}\n",
-                    details.verification_uri().to_string(),
+                    uri.secret(),
                     details.user_code().secret().to_string()
                 )?;
                 let _ = ctx.browser(host, uri.secret());


### PR DESCRIPTION
Also print the full verification URI, including the `user_code` as a query parameter.

Should be revisited after [Console#999](https://github.com/oxidecomputer/console/issues/999) is fixed.