### PR TITLE
Fix some CI tests

### DIFF
--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -59,10 +59,11 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: start omicron locally
+      - name: Start omicron locally
         shell: bash
         run: |
           make start-omicron
+          docker logs nexus
 
       - name: Run cargo test
         run: |

--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ start-cockroachdb: ## Start CockroachDB.
 	@echo "Waiting for CockroachDB to start..."
 	@sleep 5
 
-OMICRON_DOCKER_VERSION:=ci
+OMICRON_DOCKER_VERSION:=2bb595bcad1403c2597dcb405a5cfe4c67aa9c2e
 
 .PHONY: start-omicron
 start-omicron: start-cockroachdb ## Start Omicron.

--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ start-cockroachdb: ## Start CockroachDB.
 	@echo "Waiting for CockroachDB to start..."
 	@sleep 5
 
-OMICRON_DOCKER_VERSION:=main
+OMICRON_DOCKER_VERSION:=ci
 
 .PHONY: start-omicron
 start-omicron: start-cockroachdb ## Start Omicron.

--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ start-cockroachdb: ## Start CockroachDB.
 	@echo "Waiting for CockroachDB to start..."
 	@sleep 5
 
-OMICRON_DOCKER_VERSION:=2bb595bcad1403c2597dcb405a5cfe4c67aa9c2e
+OMICRON_DOCKER_VERSION:=main
 
 .PHONY: start-omicron
 start-omicron: start-cockroachdb ## Start Omicron.

--- a/src/cmd_auth.rs
+++ b/src/cmd_auth.rs
@@ -632,6 +632,7 @@ mod test {
                     }
                 }
                 Err(err) => {
+                    dbg!(&err);
                     let stdout = std::fs::read_to_string(stdout_path).unwrap();
                     let stderr = std::fs::read_to_string(stderr_path).unwrap();
                     assert_eq!(stdout, t.want_out, "test {}", t.name);

--- a/src/cmd_auth.rs
+++ b/src/cmd_auth.rs
@@ -632,7 +632,6 @@ mod test {
                     }
                 }
                 Err(err) => {
-                    dbg!(&err);
                     let stdout = std::fs::read_to_string(stdout_path).unwrap();
                     let stderr = std::fs::read_to_string(stderr_path).unwrap();
                     assert_eq!(stdout, t.want_out, "test {}", t.name);

--- a/src/cmd_auth.rs
+++ b/src/cmd_auth.rs
@@ -534,7 +534,6 @@ mod test {
 
     // TODO(https://github.com/oxidecomputer/cli/issues/204): Fix this test.
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    #[ignore]
     #[serial_test::serial]
     async fn test_cmd_auth() {
         let test_host =

--- a/src/cmd_auth.rs
+++ b/src/cmd_auth.rs
@@ -532,7 +532,6 @@ mod test {
         want_err: String,
     }
 
-    // TODO(https://github.com/oxidecomputer/cli/issues/204): Fix this test.
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[serial_test::serial]
     async fn test_cmd_auth() {

--- a/src/colors.rs
+++ b/src/colors.rs
@@ -144,6 +144,7 @@ impl ColorScheme {
 #[cfg(test)]
 mod test {
     use pretty_assertions::assert_eq;
+    use serial_test::serial;
     use test_context::{test_context, TestContext};
 
     use super::*;
@@ -195,7 +196,7 @@ mod test {
 
     #[test_context(Context)]
     #[test]
-    #[serial_test::serial]
+    #[serial]
     fn test_env_color_disabled() {
         let tests = vec![
             TestItem {
@@ -247,6 +248,7 @@ mod test {
 
     #[test_context(Context)]
     #[test]
+    #[serial]
     fn test_env_color_forced() {
         let tests = vec![
             TestItem {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -104,6 +104,7 @@ impl AsyncTestContext for MainContext {
 }
 
 // TODO(https://github.com/oxidecomputer/cli/issues/204): Fix this test.
+// Currently breaks trying to get `test_sled_id` in the test context setup.
 #[test_context(MainContext)]
 #[ignore]
 #[tokio::test]

--- a/src/update.rs
+++ b/src/update.rs
@@ -255,6 +255,9 @@ mod test {
     use pretty_assertions::assert_eq;
 
     // TODO(https://github.com/oxidecomputer/cli/issues/204): Fix this test.
+    // This test seems to be broken because dl.oxide.computer responds with
+    // <?xml version='1.0' encoding='UTF-8'?><Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message></Error>
+    // for any release.
     #[tokio::test]
     #[ignore]
     async fn test_download_binary_to_temp_file() {
@@ -291,9 +294,7 @@ mod test {
         );
     }
 
-    // TODO(https://github.com/oxidecomputer/cli/issues/204): Fix this test.
     #[tokio::test]
-    #[ignore]
     #[serial_test::serial]
     async fn test_check_for_update() {
         let result = super::check_for_update("0.0.1", true).await.unwrap();

--- a/tests/omicron.toml
+++ b/tests/omicron.toml
@@ -2,9 +2,6 @@
 # Oxide API: example configuration file
 #
 
-# Identifier for this instance of Nexus
-id = "e6bff1ff-24fb-49dc-a54e-c6a350cd4d6c"
-
 [console]
 # Directory for static assets. Absolute path or relative to CWD.
 static_dir = "nexus/static" # TODO: figure out value
@@ -21,20 +18,29 @@ session_absolute_timeout_minutes = 480
 # TODO(https://github.com/oxidecomputer/omicron/issues/372): Remove "spoof".
 schemes_external = ["spoof", "session_cookie"]
 
-[database]
+[deployment]
+# Identifier for this instance of Nexus
+id = "e6bff1ff-24fb-49dc-a54e-c6a350cd4d6c"
+rack_id = "c19a698f-c6f9-4a17-ae30-20d711b8f7dc"
+
+[deployment.database]
 # URL for connecting to the database
+type = "from_url"
 url = "postgresql://root@0.0.0.0:26257/omicron?sslmode=disable"
 
-[dropshot_external]
+[deployment.dropshot_external]
 # IP address and TCP port on which to listen for the external API
 bind_address = "0.0.0.0:8888"
 # Allow larger request bodies (1MiB) to accomodate firewall endpoints (one
 # rule is ~500 bytes)
 request_body_max_bytes = 1048576
 
-[dropshot_internal]
+[deployment.dropshot_internal]
 # IP address and TCP port on which to listen for the internal API
 bind_address = "0.0.0.0:12221"
+
+[deployment.subnet]
+net = "fd00:1122:3344:0100::/56"
 
 [log]
 # Show log messages of this level and more severe


### PR DESCRIPTION
Fixes some (but not all) of #204. Requires a new docker image from [Omicron#1384](https://github.com/oxidecomputer/omicron/pull/1384) to allow Nexus to even potentially run (missing dependencies), and updates the `omicron.toml` configuration so that Nexus _can_ run (`[deployment]` changes).