### PR TITLE
Bump version to 0.2.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1291,9 +1291,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.14"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
  "serde",
@@ -1519,7 +1519,7 @@ dependencies = [
 
 [[package]]
 name = "oxide"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "Inflector",
  "ansi_term",
@@ -1585,9 +1585,9 @@ dependencies = [
 
 [[package]]
 name = "oxide-api"
-version = "0.1.0-rc.38"
+version = "0.1.0-rc.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9927ced350416b46e46e6209c012fb04763e5165ed1746130401e68bdf72bd1b"
+checksum = "9d3e83f137e1ef8a00b535aa3c1a17b89d8cc6b62134271b967727361b66917d"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2914,9 +2914,9 @@ dependencies = [
 
 [[package]]
 name = "value-bag"
-version = "1.0.0-alpha.8"
+version = "1.0.0-alpha.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79923f7731dc61ebfba3633098bf3ac533bbd35ccd8c57e7088d9a5eebe0263f"
+checksum = "2209b78d1249f7e6f3293657c9779fe31ced465df091bbd433a1cf88e916ec55"
 dependencies = [
  "ctor",
  "version_check 0.9.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxide"
-version = "0.2.6"
+version = "0.2.7"
 edition = "2021"
 build = "build.rs"
 
@@ -31,7 +31,7 @@ regex = "1"
 num-traits = "^0.2.14"
 oauth2 = "4.1"
 open = "^2.1.1"
-oxide-api = "0.1.0-rc.38"
+oxide-api = "0.1.0-rc.39"
 #oxide-api = { path= "../oxide.rs/oxide" }
 parse-display = "^0.5.5"
 pulldown-cmark = "^0.9.1"

--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ Updating the API spec is as simple as updating the [`spec.json`](spec.json) file
 you `cargo build`. It likely might need some tender love and care to make it a nice command like the other generated ones
 if it is out of the ordinary.
 
+**Important: Currently we are transitioning to use progenitor as a client generator instead of the current client generator.**
+**This means that as a temporary work around the spec.json file must be copied from oxide.rs and you must make sure all tags don't change**
+
 Only `create`, `edit`, `view/get`, `list`, `delete` commands are generated. The rest are bespoke and any generation lead to something
 that seemed harder to maintain over time. But if you are brave you can try.
 
@@ -73,4 +76,3 @@ Then, simply run `make`. Binaries will be available in `cross/`.
 If you want to only build one of the cross targets, supply the `CROSS_TARGETS` environment variable:
 
     CROSS_TARGETS=x86_64-unknown-linux-musl make
-

--- a/spec.json
+++ b/spec.json
@@ -10,6 +10,108 @@
     "version": "0.0.1"
   },
   "paths": {
+    "/device/auth": {
+      "post": {
+        "tags": [
+          "hidden"
+        ],
+        "summary": "Start an OAuth 2.0 Device Authorization Grant",
+        "description": "This endpoint is designed to be accessed from an *unauthenticated* API client. It generates and records a `device_code` and `user_code` which must be verified and confirmed prior to a token being granted.",
+        "operationId": "device_auth_request",
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/DeviceAuthRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "default": {
+            "description": "",
+            "content": {
+              "*/*": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/device/confirm": {
+      "post": {
+        "tags": [
+          "hidden"
+        ],
+        "summary": "Confirm an OAuth 2.0 Device Authorization Grant",
+        "description": "This endpoint is designed to be accessed by the user agent (browser), not the client requesting the token. So we do not actually return the token here; it will be returned in response to the poll on `/device/token`.",
+        "operationId": "device_auth_confirm",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DeviceAuthVerify"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Null",
+                  "type": "string",
+                  "enum": [
+                    null
+                  ]
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/device/token": {
+      "post": {
+        "tags": [
+          "hidden"
+        ],
+        "summary": "Request a device access token",
+        "description": "This endpoint should be polled by the client until the user code is verified and the grant is confirmed.",
+        "operationId": "device_access_token",
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/DeviceAccessTokenRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "default": {
+            "description": "",
+            "content": {
+              "*/*": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
     "/hardware/racks": {
       "get": {
         "tags": [
@@ -694,7 +796,7 @@
         }
       }
     },
-    "/ip-pools/{pool_name}/ranges/delete": {
+    "/ip-pools/{pool_name}/ranges/remove": {
       "post": {
         "tags": [
           "ip-pools"
@@ -829,6 +931,17 @@
             "style": "simple"
           }
         ],
+        "requestBody": {
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            }
+          },
+          "required": true
+        },
         "responses": {
           "default": {
             "description": "",
@@ -2828,7 +2941,7 @@
         }
       }
     },
-    "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/serial": {
+    "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/serial-console": {
       "get": {
         "tags": [
           "instances"
@@ -3685,7 +3798,7 @@
     "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/firewall/rules": {
       "get": {
         "tags": [
-          "firewall"
+          "vpcs"
         ],
         "summary": "List firewall rules for a VPC.",
         "operationId": "vpc_firewall_rules_get",
@@ -3739,7 +3852,7 @@
       },
       "put": {
         "tags": [
-          "firewall"
+          "vpcs"
         ],
         "summary": "Replace the firewall rules for a VPC",
         "operationId": "vpc_firewall_rules_put",
@@ -5744,7 +5857,7 @@
           "silos"
         ],
         "summary": "Create a new SAML identity provider for a silo.",
-        "operationId": "silo_saml_idp_create",
+        "operationId": "silo_saml_idp_fetch",
         "parameters": [
           {
             "in": "path",
@@ -5793,7 +5906,7 @@
           "silos"
         ],
         "summary": "GET a silo's SAML identity provider",
-        "operationId": "silo_saml_idp_fetch",
+        "operationId": "silo_saml_idp_create",
         "parameters": [
           {
             "in": "path",
@@ -5823,6 +5936,105 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/SamlIdentityProvider"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/system/user": {
+      "get": {
+        "tags": [
+          "system"
+        ],
+        "summary": "List the built-in system users",
+        "operationId": "system_user_list",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "description": "Maximum number of items returned by a single call",
+            "schema": {
+              "nullable": true,
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 1
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page_token",
+            "description": "Token returned by previous call to retrieve the subsequent page",
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sort_by",
+            "schema": {
+              "$ref": "#/components/schemas/NameSortMode"
+            },
+            "style": "form"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserBuiltinResultsPage"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        },
+        "x-dropshot-pagination": true
+      }
+    },
+    "/system/user/{user_name}": {
+      "get": {
+        "tags": [
+          "system"
+        ],
+        "summary": "Fetch a specific built-in system user",
+        "operationId": "system_user_view",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "user_name",
+            "description": "The built-in user's unique name.",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserBuiltin"
                 }
               }
             }
@@ -5967,105 +6179,6 @@
         },
         "x-dropshot-pagination": true
       }
-    },
-    "/users_builtin": {
-      "get": {
-        "tags": [
-          "system"
-        ],
-        "summary": "List the built-in system users",
-        "operationId": "builtin_users_get",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "limit",
-            "description": "Maximum number of items returned by a single call",
-            "schema": {
-              "nullable": true,
-              "type": "integer",
-              "format": "uint32",
-              "minimum": 1
-            },
-            "style": "form"
-          },
-          {
-            "in": "query",
-            "name": "page_token",
-            "description": "Token returned by previous call to retrieve the subsequent page",
-            "schema": {
-              "nullable": true,
-              "type": "string"
-            },
-            "style": "form"
-          },
-          {
-            "in": "query",
-            "name": "sort_by",
-            "schema": {
-              "$ref": "#/components/schemas/NameSortMode"
-            },
-            "style": "form"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UserBuiltinResultsPage"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "$ref": "#/components/responses/Error"
-          },
-          "5XX": {
-            "$ref": "#/components/responses/Error"
-          }
-        },
-        "x-dropshot-pagination": true
-      }
-    },
-    "/users_builtin/{user_name}": {
-      "get": {
-        "tags": [
-          "system"
-        ],
-        "summary": "Fetch a specific built-in system user",
-        "operationId": "builtin_users_get_user",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "user_name",
-            "description": "The built-in user's unique name.",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/Name"
-            },
-            "style": "simple"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UserBuiltin"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "$ref": "#/components/responses/Error"
-          },
-          "5XX": {
-            "$ref": "#/components/responses/Error"
-          }
-        }
-      }
     }
   },
   "components": {
@@ -6127,6 +6240,49 @@
         "required": [
           "private_key",
           "public_cert"
+        ]
+      },
+      "DeviceAccessTokenRequest": {
+        "type": "object",
+        "properties": {
+          "client_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "device_code": {
+            "type": "string"
+          },
+          "grant_type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "client_id",
+          "device_code",
+          "grant_type"
+        ]
+      },
+      "DeviceAuthRequest": {
+        "type": "object",
+        "properties": {
+          "client_id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "client_id"
+        ]
+      },
+      "DeviceAuthVerify": {
+        "type": "object",
+        "properties": {
+          "user_code": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "user_code"
         ]
       },
       "Digest": {
@@ -8906,6 +9062,14 @@
             "description": "timestamp when this resource was last modified",
             "type": "string",
             "format": "date-time"
+          },
+          "user_provision_type": {
+            "description": "User provision type",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/UserProvisionType"
+              }
+            ]
           }
         },
         "required": [
@@ -8914,7 +9078,8 @@
           "id",
           "name",
           "time_created",
-          "time_modified"
+          "time_modified",
+          "user_provision_type"
         ]
       },
       "SiloCreate": {
@@ -8929,12 +9094,16 @@
           },
           "name": {
             "$ref": "#/components/schemas/Name"
+          },
+          "user_provision_type": {
+            "$ref": "#/components/schemas/UserProvisionType"
           }
         },
         "required": [
           "description",
           "discoverable",
-          "name"
+          "name",
+          "user_provision_type"
         ]
       },
       "SiloResultsPage": {
@@ -9317,12 +9486,17 @@
         "description": "Client view of a [`User`]",
         "type": "object",
         "properties": {
+          "display_name": {
+            "description": "Human-readable name that can identify the user",
+            "type": "string"
+          },
           "id": {
             "type": "string",
             "format": "uuid"
           }
         },
         "required": [
+          "display_name",
           "id"
         ]
       },
@@ -9385,6 +9559,14 @@
         },
         "required": [
           "items"
+        ]
+      },
+      "UserProvisionType": {
+        "description": "How users will be provisioned in a silo during authentication.",
+        "type": "string",
+        "enum": [
+          "fixed",
+          "jit"
         ]
       },
       "UserResultsPage": {
@@ -10306,6 +10488,13 @@
       }
     },
     {
+      "name": "hardware",
+      "description": "These operations pertain to hardware inventory and management. Racks are the unit of expansion of an Oxide deployment. Racks are in turn composed of sleds, switches, power supplies, and a cabled backplane.",
+      "externalDocs": {
+        "url": "http://oxide.computer/docs/#xxx"
+      }
+    },
+    {
       "name": "hidden",
       "description": "TODO operations that will not ship to customers",
       "externalDocs": {
@@ -10411,8 +10600,8 @@
       }
     },
     {
-      "name": "silos",
-      "description": "Silos represent a logical partition of users and resources.",
+      "name": "session",
+      "description": "Information pertaining to the current session.",
       "externalDocs": {
         "url": "http://oxide.computer/docs/#xxx"
       }
@@ -10420,6 +10609,13 @@
     {
       "name": "sleds",
       "description": "This tag should be moved into hardware",
+      "externalDocs": {
+        "url": "http://oxide.computer/docs/#xxx"
+      }
+    },
+    {
+      "name": "silos",
+      "description": "Silos represent a logical partition of users and resources.",
       "externalDocs": {
         "url": "http://oxide.computer/docs/#xxx"
       }


### PR DESCRIPTION
This commit bumps version to 0.2.7 and updates oxide-api to 0.1.0-rc.39.

A special consideration is made to this update in particular. Due to [ongoing work](https://github.com/oxidecomputer/omicron/pull/1329#issuecomment-1175806211), we have implemented a temporary work around to tags and operation IDs.

Info on the README change

```markdown
**Important: Currently we are transitioning to use progenitor as a client generator instead of the current client generator.**
**This means that as a temporary work around the spec.json file must be copied from oxide.rs and you must make sure all tags don't change**
```