### PR TITLE
Remove pager command

### DIFF
--- a/src/cmd_config.rs
+++ b/src/cmd_config.rs
@@ -7,8 +7,6 @@ use clap::Parser;
 /// Current respected settings:
 /// - editor: the text editor program to use for authoring text
 /// - prompt: toggle interactive prompting in the terminal (default: "enabled")
-// Remove
-// /// - pager: the terminal pager program to send standard output to
 /// - browser: the web browser to use for opening URLs
 /// - format: the formatting style for command output
 #[derive(Parser, Debug, Clone)]

--- a/src/cmd_config.rs
+++ b/src/cmd_config.rs
@@ -7,7 +7,8 @@ use clap::Parser;
 /// Current respected settings:
 /// - editor: the text editor program to use for authoring text
 /// - prompt: toggle interactive prompting in the terminal (default: "enabled")
-/// - pager: the terminal pager program to send standard output to
+// Remove
+// /// - pager: the terminal pager program to send standard output to
 /// - browser: the web browser to use for opening URLs
 /// - format: the formatting style for command output
 #[derive(Parser, Debug, Clone)]
@@ -172,7 +173,7 @@ mod test {
             TestItem {
                 name: "list empty".to_string(),
                 cmd: crate::cmd_config::SubCommand::List(crate::cmd_config::CmdConfigList { host: "".to_string() }),
-                want_out: "editor=\nprompt=enabled\npager=\nbrowser=\nformat=table\n".to_string(),
+                want_out: "editor=\nprompt=enabled\nbrowser=\nformat=table\n".to_string(),
                 want_err: "".to_string(),
             },
             TestItem {
@@ -235,7 +236,7 @@ mod test {
             TestItem {
                 name: "list all default".to_string(),
                 cmd: crate::cmd_config::SubCommand::List(crate::cmd_config::CmdConfigList { host: "".to_string() }),
-                want_out: "editor=\nprompt=enabled\npager=\nbrowser=bar\nformat=table\n".to_string(),
+                want_out: "editor=\nprompt=enabled\nbrowser=bar\nformat=table\n".to_string(),
                 want_err: "".to_string(),
             },
         ];

--- a/src/config.rs
+++ b/src/config.rs
@@ -70,16 +70,10 @@ pub fn config_options() -> Vec<ConfigOption> {
             allowed_values: vec!["enabled".to_string(), "disabled".to_string()],
         },
         ConfigOption {
-            key: "pager".to_string(),
-            description: "the terminal pager program to send standard output to".to_string(),
-            comment: "A pager program to send command output to, e.g. \"less\". Set the value to \"cat\" to disable the pager.".to_string(),
-            default_value: "".to_string(),
-            allowed_values: vec![],
-        },
-        ConfigOption {
             key: "browser".to_string(),
             description: "the web browser to use for opening URLs".to_string(),
-            comment: "What web browser oxide should use when opening URLs. If blank, will refer to environment.".to_string(),
+            comment: "What web browser oxide should use when opening URLs. If blank, will refer to environment."
+                .to_string(),
             default_value: "".to_string(),
             allowed_values: vec![],
         },
@@ -187,14 +181,12 @@ mod test {
         let mut c = new_blank_config().unwrap();
         assert!(c.set("", "editor", "vim").is_ok());
         assert!(c.set("", "prompt", "disabled").is_ok());
-        assert!(c.set("", "pager", "less").is_ok());
         assert!(c.set("", "browser", "firefox").is_ok());
         assert!(c.set("", "format", "table").is_ok());
 
         let doc = c.config_to_string().unwrap();
         assert!(doc.contains("editor = \"vim\""));
         assert!(doc.contains("prompt = \"disabled\""));
-        assert!(doc.contains("pager = \"less\""));
         assert!(doc.contains("browser = \"firefox\""));
         assert!(doc.contains("format = \"table\""));
     }
@@ -204,7 +196,6 @@ mod test {
         let mut c = new_blank_config().unwrap();
         assert!(c.set("example.com", "editor", "vim").is_ok());
         assert!(c.set("example.com", "prompt", "disabled").is_ok());
-        assert!(c.set("example.com", "pager", "less").is_ok());
         assert!(c.set("example.com", "browser", "firefox").is_ok());
         assert!(c.set("oxide.computer", "browser", "chrome").is_ok());
 
@@ -213,7 +204,6 @@ mod test {
         let expected = r#"["example.com"]
 editor = "vim"
 prompt = "disabled"
-pager = "less"
 browser = "firefox"
 
 ["oxide.computer"]
@@ -237,9 +227,6 @@ editor = ""
 # When to interactively prompt. This is a global config that cannot be overridden by hostname.
 # Supported values: enabled, disabled
 prompt = "enabled"
-
-# A pager program to send command output to, e.g. "less". Set the value to "cat" to disable the pager.
-pager = ""
 
 # What web browser oxide should use when opening URLs. If blank, will refer to environment.
 browser = ""

--- a/src/context.rs
+++ b/src/context.rs
@@ -21,19 +21,6 @@ impl Context<'_> {
             io.set_never_prompt(true)
         }
 
-        // Set the pager.
-        // Pager precedence
-        // 1. OXIDE_PAGER
-        // 2. pager from config
-        // 3. PAGER
-        if let Ok(oxide_pager) = std::env::var("OXIDE_PAGER") {
-            io.set_pager(oxide_pager);
-        } else if let Ok(pager) = config.get("", "pager") {
-            if !pager.is_empty() {
-                io.set_pager(pager);
-            }
-        }
-
         // Check if we should force use the tty.
         if let Ok(oxide_force_tty) = std::env::var("OXIDE_FORCE_TTY") {
             if !oxide_force_tty.is_empty() {
@@ -134,26 +121,17 @@ mod test {
     use super::*;
 
     struct TContext {
-        orig_oxide_pager_env: Result<String, std::env::VarError>,
         orig_oxide_force_tty_env: Result<String, std::env::VarError>,
     }
 
     impl TestContext for TContext {
         fn setup() -> TContext {
             TContext {
-                orig_oxide_pager_env: std::env::var("OXIDE_PAGER"),
                 orig_oxide_force_tty_env: std::env::var("OXIDE_FORCE_TTY"),
             }
         }
 
         fn teardown(self) {
-            // Put the original env var back.
-            if let Ok(ref val) = self.orig_oxide_pager_env {
-                std::env::set_var("OXIDE_PAGER", val);
-            } else {
-                std::env::remove_var("OXIDE_PAGER");
-            }
-
             if let Ok(ref val) = self.orig_oxide_force_tty_env {
                 std::env::set_var("OXIDE_FORCE_TTY", val);
             } else {
@@ -164,11 +142,8 @@ mod test {
 
     pub struct TestItem {
         name: String,
-        oxide_pager_env: String,
         oxide_force_tty_env: String,
-        pager: String,
         prompt: String,
-        want_pager: String,
         want_prompt: String,
         want_terminal_width_override: i32,
     }
@@ -179,52 +154,16 @@ mod test {
     fn test_context() {
         let tests = vec![
             TestItem {
-                name: "OXIDE_PAGER env".to_string(),
-                oxide_pager_env: "more".to_string(),
-                oxide_force_tty_env: "".to_string(),
-                prompt: "".to_string(),
-                pager: "".to_string(),
-                want_pager: "more".to_string(),
-                want_prompt: "enabled".to_string(),
-                want_terminal_width_override: 0,
-            },
-            TestItem {
-                name: "OXIDE_PAGER env override".to_string(),
-                oxide_pager_env: "more".to_string(),
-                oxide_force_tty_env: "".to_string(),
-                prompt: "".to_string(),
-                pager: "less".to_string(),
-                want_pager: "more".to_string(),
-                want_prompt: "enabled".to_string(),
-                want_terminal_width_override: 0,
-            },
-            TestItem {
-                name: "config pager".to_string(),
-                oxide_pager_env: "".to_string(),
-                oxide_force_tty_env: "".to_string(),
-                prompt: "".to_string(),
-                pager: "less".to_string(),
-                want_pager: "less".to_string(),
-                want_prompt: "enabled".to_string(),
-                want_terminal_width_override: 0,
-            },
-            TestItem {
                 name: "config prompt".to_string(),
-                oxide_pager_env: "".to_string(),
                 oxide_force_tty_env: "".to_string(),
                 prompt: "disabled".to_string(),
-                pager: "less".to_string(),
-                want_pager: "less".to_string(),
                 want_prompt: "disabled".to_string(),
                 want_terminal_width_override: 0,
             },
             TestItem {
                 name: "OXIDE_FORCE_TTY env".to_string(),
-                oxide_pager_env: "".to_string(),
                 oxide_force_tty_env: "120".to_string(),
                 prompt: "disabled".to_string(),
-                pager: "less".to_string(),
-                want_pager: "less".to_string(),
                 want_prompt: "disabled".to_string(),
                 want_terminal_width_override: 120,
             },
@@ -234,18 +173,8 @@ mod test {
             let mut config = crate::config::new_blank_config().unwrap();
             let mut c = crate::config_from_env::EnvConfig::inherit_env(&mut config);
 
-            if !t.pager.is_empty() {
-                c.set("", "pager", &t.pager).unwrap();
-            }
-
             if !t.prompt.is_empty() {
                 c.set("", "prompt", &t.prompt).unwrap();
-            }
-
-            if !t.oxide_pager_env.is_empty() {
-                std::env::set_var("OXIDE_PAGER", t.oxide_pager_env.clone());
-            } else {
-                std::env::remove_var("OXIDE_PAGER");
             }
 
             if !t.oxide_force_tty_env.is_empty() {
@@ -256,8 +185,6 @@ mod test {
 
             let ctx = Context::new(&mut c);
 
-            assert_eq!(ctx.io.get_pager(), t.want_pager, "test: {}", t.name);
-
             assert_eq!(
                 ctx.io.get_never_prompt(),
                 t.want_prompt == "disabled",
@@ -265,7 +192,6 @@ mod test {
                 t.name
             );
 
-            assert_eq!(ctx.config.get("", "pager").unwrap(), t.want_pager, "test: {}", t.name);
             assert_eq!(ctx.config.get("", "prompt").unwrap(), t.want_prompt, "test: {}", t.name);
 
             if t.want_terminal_width_override > 0 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,9 +104,6 @@ use slog::Drain;
 ///
 /// DEBUG: set to any value to enable verbose output to standard error.
 ///
-/// OXIDE_PAGER, PAGER (in order of precedence): a terminal paging program to send
-/// standard output to, e.g. "less".
-///
 /// NO_COLOR: set to any value to avoid printing ANSI escape sequences for color output.
 ///
 /// CLICOLOR: set to "0" to disable printing ANSI colors in output.
@@ -125,12 +122,12 @@ use slog::Drain;
 ///
 /// OXIDE_CONFIG_DIR: the directory where oxide will store configuration files.
 /// Default: "$XDG_CONFIG_HOME/oxide" or "$HOME/.config/oxide".
-/// 
+///
 /// Authentication
 ///
 /// You can get an access token running `oxide auth login`. This will contact `OXIDE_HOST`
-/// and attempt an OAuth 2.0 Device Authorization Grant. 
-/// The CLI will attempt to open a browser window with which you can login 
+/// and attempt an OAuth 2.0 Device Authorization Grant.
+/// The CLI will attempt to open a browser window with which you can login
 /// (via SAML or other IdP method) and type in or verify the user code printed in the terminal.
 /// After a successful login and code verification, a token associated with the logged-in
 /// user will be granted and stored in the config file.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -222,6 +222,7 @@ async fn test_main(ctx: &mut MainContext) {
             name: "api /session/me".to_string(),
             args: vec!["oxide".to_string(), "api".to_string(), "/session/me".to_string()],
             want_out: r#"{
+  "display_name": "privileged",
   "id": "001de000-05e4-4000-8000-000000004007"
 }"#
             .to_string(),
@@ -233,6 +234,7 @@ async fn test_main(ctx: &mut MainContext) {
             name: "api session/me (no leading /)".to_string(),
             args: vec!["oxide".to_string(), "api".to_string(), "session/me".to_string()],
             want_out: r#"{
+  "display_name": "privileged",
   "id": "001de000-05e4-4000-8000-000000004007"
 }"#
             .to_string(),
@@ -250,6 +252,7 @@ async fn test_main(ctx: &mut MainContext) {
                 "Origin: https://example.com".to_string(),
             ],
             want_out: r#"{
+  "display_name": "privileged",
   "id": "001de000-05e4-4000-8000-000000004007"
 }"#
             .to_string(),
@@ -269,6 +272,7 @@ async fn test_main(ctx: &mut MainContext) {
                 "Another: thing".to_string(),
             ],
             want_out: r#"{
+  "display_name": "privileged",
   "id": "001de000-05e4-4000-8000-000000004007"
 }"#
             .to_string(),
@@ -284,10 +288,7 @@ async fn test_main(ctx: &mut MainContext) {
                 "session/me".to_string(),
                 "--include".to_string(),
             ],
-            want_out: r#"HTTP/1.1 200 OK
-content-length:  "45"
-content-type:    "application/json"
-date:"#
+            want_out: r#"HTTP/1.1 200 OK"#
                 .to_string(),
             want_err: "".to_string(),
             want_code: 0,


### PR DESCRIPTION
Currently this command has not been [fully implemented](https://github.com/oxidecomputer/cli/blob/main/src/iostreams.rs#L180-L181).

For the time being this command will not be worked on, so it's best to remove it until there is time to fully implement it.