### PR TITLE
Fix test_context usage

### DIFF
--- a/src/cmd_org.rs
+++ b/src/cmd_org.rs
@@ -89,7 +89,7 @@ mod test {
     #[test_context(TContext)]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[serial_test::serial]
-    async fn test_cmd_org() {
+    async fn test_cmd_org(_ctx: &mut TContext) {
         let tests: Vec<TestItem> = vec![
             TestItem {
                 name: "create no name".to_string(),

--- a/src/cmd_ssh_key.rs
+++ b/src/cmd_ssh_key.rs
@@ -453,7 +453,7 @@ mod test {
     #[test_context(TContext)]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[serial_test::serial]
-    async fn test_cmd_ssh_key() {
+    async fn test_cmd_ssh_key(_ctx: &mut TContext) {
         let tests: Vec<TestItem> = vec![
             TestItem {
                 name: "empty key list".to_string(),

--- a/src/colors.rs
+++ b/src/colors.rs
@@ -197,7 +197,7 @@ mod test {
     #[test_context(Context)]
     #[test]
     #[serial]
-    fn test_env_color_disabled() {
+    fn test_env_color_disabled(_ctx: &mut Context) {
         let tests = vec![
             TestItem {
                 name: "pristine env".to_string(),
@@ -249,7 +249,7 @@ mod test {
     #[test_context(Context)]
     #[test]
     #[serial]
-    fn test_env_color_forced() {
+    fn test_env_color_forced(_ctx: &mut Context) {
         let tests = vec![
             TestItem {
                 name: "pristine env".to_string(),

--- a/src/context.rs
+++ b/src/context.rs
@@ -151,7 +151,7 @@ mod test {
     #[test_context(TContext)]
     #[test]
     #[serial_test::serial]
-    fn test_context() {
+    fn test_context(_ctx: &mut TContext) {
         let tests = vec![
             TestItem {
                 name: "config prompt".to_string(),


### PR DESCRIPTION
Thought I would proactively reach out on this, hopefully before you were bit by it.

Up until now, the arguments given in a test that used the
test-context crate's utilities were ignored. Thus, the way it was used
in this repo (not specifying any argument in the test) compiled,
although was irregular.

As of 0.1.4 of test-context, the argument list provided in the written
test will be used verbatim, and so writing out the arguments IS
necessary.

This commit provides some ignored arguments to prevent any breaking that
might occur using 0.1.4 of test-context.