### PR TITLE
Allow creating stopped instance.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1796,9 +1796,9 @@ dependencies = [
 
 [[package]]
 name = "oxide-api"
-version = "0.1.0-rc.40"
+version = "0.1.0-rc.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e70dd62a963e00455ed648d011f3bb55a8b2c534e33383902bf4d53ea01dbf1c"
+checksum = "dce0e8416b4283f082058e1d1434d42a5db7d5470761c67234701f461e67c049"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ regex = "1"
 num-traits = "^0.2.14"
 oauth2 = "4.1"
 open = "^2.1.1"
-oxide-api = "0.1.0-rc.40"
+oxide-api = "0.1.0-rc.41"
 #oxide-api = { path= "../oxide.rs/oxide" }
 parse-display = "^0.5.5"
 pulldown-cmark = "^0.9.1"

--- a/cli-macro-impl/src/lib.rs
+++ b/cli-macro-impl/src/lib.rs
@@ -1025,6 +1025,21 @@ impl Operation {
                 quote! {
                     #[clap(#long_flag, #short_flag multiple_values = true)]
                 }
+            } else if rendered == "bool" {
+                // Clap treats bools as flags, so any value passed is ignored
+                // just whether the argument is present or not is used.
+                // So if a default value of true is passed, there's no way to
+                // set the flag to false. We use `parse(try_from_str)` to
+                // allow passing true or false as the value.
+                // Perhaps we could be smart and generate --foo / --no-foo?
+                let default = default
+                    .map(|d| d.to_string())
+                    .map(|d| quote! { parse(try_from_str), default_value = #d })
+                    .unwrap_or_else(|| quote! { });
+
+                quote! {
+                    #[clap(#long_flag, #short_flag #default)]
+                }
             } else {
                 let default = default
                     .map(|d| d.to_string())

--- a/cli-macro-impl/src/lib.rs
+++ b/cli-macro-impl/src/lib.rs
@@ -1031,10 +1031,14 @@ impl Operation {
                 // So if a default value of true is passed, there's no way to
                 // set the flag to false. We use `parse(try_from_str)` to
                 // allow passing true or false as the value.
+                // To also allow passing the flag without a value, we use
+                // `default_missing_value`.
                 // Perhaps we could be smart and generate --foo / --no-foo?
                 let default = default
                     .map(|d| d.to_string())
-                    .map(|d| quote! { parse(try_from_str), default_value = #d })
+                    .map(|d| quote! {
+                        parse(try_from_str), default_value = #d, default_missing_value = #d
+                    })
                     .unwrap_or_else(|| quote! { });
 
                 quote! {

--- a/cli-macro-impl/tests/gen/instances.rs.gen
+++ b/cli-macro-impl/tests/gen/instances.rs.gen
@@ -97,8 +97,17 @@ pub struct CmdInstanceCreate {
     #[doc = "The network interfaces to be created for this instance."]
     #[clap(long = "network-interfaces", short = 'n')]
     pub network_interfaces: Option<oxide_api::types::InstanceNetworkInterfaceAttachment>,
+    #[doc = "Should this instance be started upon creation; true by default."]
+    #[clap(
+        long = "start",
+        short = 's',
+        parse(try_from_str),
+        default_value = "true",
+        default_missing_value = "true"
+    )]
+    pub start: bool,
     #[doc = "User data for instance initialization systems (such as cloud-init). Must be a Base64-encoded string, as specified in RFC 4648 § 4 (+ and / characters with padding). Maximum 32 KiB unencoded data."]
-    #[clap(long = "user-data", short = 'u', default_value_t)]
+    #[clap(long = "user-data", short = 'u', default_value = "\"\"")]
     pub user_data: String,
 }
 
@@ -273,6 +282,7 @@ impl crate::cmd::Command for CmdInstanceCreate {
                     name: instance.clone(),
                     ncpus: ncpus.clone(),
                     network_interfaces: self.network_interfaces.clone(),
+                    start: self.start.clone(),
                     user_data: self.user_data.clone(),
                 },
             )

--- a/docs/oxide.json
+++ b/docs/oxide.json
@@ -1404,6 +1404,11 @@
               "help": "The network interfaces to be created for this instance"
             },
             {
+              "short": "s",
+              "long": "start",
+              "help": "Should this instance be started upon creation; true by default"
+            },
+            {
               "short": "u",
               "long": "user-data",
               "help": "User data for instance initialization systems (such as cloud-init). Must be a Base64-encoded string, as specified in RFC 4648 § 4 (+ and / characters with padding). Maximum 32 KiB unencoded data"

--- a/spec.json
+++ b/spec.json
@@ -8782,6 +8782,11 @@
               }
             ]
           },
+          "start": {
+            "description": "Should this instance be started upon creation; true by default.",
+            "default": true,
+            "type": "boolean"
+          },
           "user_data": {
             "description": "User data for instance initialization systems (such as cloud-init). Must be a Base64-encoded string, as specified in RFC 4648 § 4 (+ and / characters with padding). Maximum 32 KiB unencoded data.",
             "default": "",

--- a/src/cmd_instance.rs
+++ b/src/cmd_instance.rs
@@ -558,6 +558,7 @@ mod test {
                     disks: Default::default(),
                     user_data: "some data".to_string(),
                     external_ips: Vec::from(["mypool".to_string()]),
+                    start: true,
                 }),
 
                 stdin: "".to_string(),
@@ -578,6 +579,7 @@ mod test {
                     disks: Default::default(),
                     user_data: "some data".to_string(),
                     external_ips: Vec::from(["mypool".to_string()]),
+                    start: true,
                 }),
 
                 stdin: "".to_string(),
@@ -598,6 +600,7 @@ mod test {
                     disks: Default::default(),
                     user_data: "some data".to_string(),
                     external_ips: Vec::from(["mypool".to_string()]),
+                    start: true,
                 }),
 
                 stdin: "".to_string(),
@@ -618,6 +621,7 @@ mod test {
                     disks: Default::default(),
                     user_data: "some data".to_string(),
                     external_ips: Vec::from(["mypool".to_string()]),
+                    start: true,
                 }),
 
                 stdin: "".to_string(),
@@ -638,6 +642,7 @@ mod test {
                     disks: Default::default(),
                     user_data: "some data".to_string(),
                     external_ips: Vec::from(["mypool".to_string()]),
+                    start: true,
                 }),
 
                 stdin: "".to_string(),
@@ -658,6 +663,7 @@ mod test {
                     disks: Default::default(),
                     user_data: "some data".to_string(),
                     external_ips: Vec::from(["mypool".to_string()]),
+                    start: true,
                 }),
 
                 stdin: "".to_string(),


### PR DESCRIPTION
cli side updates for https://github.com/oxidecomputer/omicron/pull/1653

This adds a `-s/--start` flag to the create operation. If it's omitted, it defaults to `true` which preserves the current behaviour. You can also explicitly specify `true` or `false`. If the flag is passed with no value, it treats that as `true`.