### PR TITLE
Update manual URL to root CLI docs page

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Oxide command line tool.
 
 The instructions below refer to instructions for contributing to the repo.
 
-For the CLI docs for end users refer to: https://docs.oxide.computer/cli/manual
+For the CLI docs for end users refer to: https://docs.oxide.computer/cli
 
 If you are running nexus locally without `https://` make sure you denote that in
 the URL you pass to `OXIDE_HOST` or to `oxide auth login`.


### PR DESCRIPTION
Hey folks - was checking out the project and went to read the docs as the first step and I think there's a dead link (or a moving target as part of maybe a move to Remix?). Thought I'd open up a PR to point to the root of the CLI docs. I checked the Wayback machine to see if there were any examples of what the `/manual` page looked like before and it has avoided being archived (🚫 🤖 ). 

No worries if this is unwanted or a work in process, just thought I'd leave this here in case someone else came along and hit the link. Fantastic docs on the CLI by the way - I love it.

Here's what I got when visiting the link in the README before - 

![image](https://user-images.githubusercontent.com/444193/194969692-9b2d678a-2c50-4800-bf6f-0b67b0c5ba88.png)

And here's what you get after visiting the link in the README after - 

<img width="1092" alt="image" src="https://user-images.githubusercontent.com/444193/194969784-f4f6625e-9d71-4d4d-a2d5-31bc84a514f4.png">
