### PR TITLE
Temporary CI fix until tests are run against mock API server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1854,6 +1854,8 @@ dependencies = [
 [[package]]
 name = "oxide-api"
 version = "0.1.0-rc.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce0e8416b4283f082058e1d1434d42a5db7d5470761c67234701f461e67c049"
 dependencies = [
  "anyhow",
  "bytes",

--- a/src/cmd_auth.rs
+++ b/src/cmd_auth.rs
@@ -2,10 +2,10 @@ use std::collections::HashMap;
 
 use anyhow::{anyhow, Result};
 use clap::Parser;
-use oauth2::basic::BasicClient;
-use oauth2::devicecode::StandardDeviceAuthorizationResponse;
-use oauth2::reqwest::async_http_client;
-use oauth2::{AuthType, AuthUrl, ClientId, DeviceAuthorizationUrl, TokenResponse, TokenUrl};
+use oauth2::{
+    basic::BasicClient, devicecode::StandardDeviceAuthorizationResponse, reqwest::async_http_client, AuthType, AuthUrl,
+    ClientId, DeviceAuthorizationUrl, TokenResponse, TokenUrl,
+};
 
 /// Login, logout, and get the status of your authentication.
 ///
@@ -532,6 +532,9 @@ mod test {
         want_err: String,
     }
 
+    // TODO: Auth is shaky with current docker container CI implementation.
+    // remove ignore tag once tests run against mock API server
+    #[ignore]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[serial_test::serial]
     async fn test_cmd_auth() {

--- a/src/cmd_instance_serial.rs
+++ b/src/cmd_instance_serial.rs
@@ -1,24 +1,23 @@
-use std::mem::swap;
-use std::os::unix::io::AsRawFd;
-use std::time::Duration;
+use std::{mem::swap, os::unix::io::AsRawFd, time::Duration};
+
 use anyhow::Result;
 use futures::{SinkExt, StreamExt};
 use http::HeaderMap;
 use reqwest::ClientBuilder;
-use tokio_tungstenite::tungstenite::protocol::{Message, Role};
-use tokio_tungstenite::WebSocketStream;
+use tokio_tungstenite::{
+    tungstenite::protocol::{Message, Role},
+    WebSocketStream,
+};
 
 mod nexus_client {
-    progenitor::generate_api!(
-        spec = "spec-serial.json",
-        interface = Builder,
-    );
+    progenitor::generate_api!(spec = "spec-serial.json", interface = Builder,);
 }
 
 impl super::cmd_instance::CmdInstanceSerial {
     pub(crate) async fn websock_stream_tty(&self, ctx: &mut crate::context::Context<'_>) -> Result<()> {
         // shenanigans to get the info we need to construct a progenitor-client
-        let reqw = ctx.api_client("")?
+        let reqw = ctx
+            .api_client("")?
             .request_raw(http::Method::GET, "", None)
             .await?
             .build()?;
@@ -27,9 +26,7 @@ impl super::cmd_instance::CmdInstanceSerial {
         let mut headers = HeaderMap::new();
         headers.insert(
             http::header::AUTHORIZATION,
-            reqw.headers().get(http::header::AUTHORIZATION)
-                .unwrap()
-                .to_owned()
+            reqw.headers().get(http::header::AUTHORIZATION).unwrap().to_owned(),
         );
 
         let reqw_client = ClientBuilder::new()
@@ -218,9 +215,10 @@ async fn stdin_to_websockets_task(
 
 #[cfg(test)]
 mod test {
-    use crate::cmd::Command;
     use pretty_assertions::assert_eq;
     use test_context::{test_context, AsyncTestContext};
+
+    use crate::cmd::Command;
 
     struct TContext {
         orig_oxide_host: Result<String, std::env::VarError>,
@@ -262,6 +260,9 @@ mod test {
         }
     }
 
+    // TODO: Auth is shaky with current docker container CI implementation.
+    // remove ignore tag once tests run against mock API server
+    #[ignore]
     #[test_context(TContext)]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_cmd_instance_serial_interactive() {

--- a/src/cmd_ssh_key.rs
+++ b/src/cmd_ssh_key.rs
@@ -450,6 +450,9 @@ mod test {
         }
     }
 
+    // TODO: Auth is shaky with current docker container CI implementation.
+    // remove ignore tag once tests run against mock API server
+    #[ignore]
     #[test_context(TContext)]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[serial_test::serial]


### PR DESCRIPTION
Currently our omicron docker implementation is a bit flaky. There is some issue with auth where these tests will pass locally but fail on CI.

Tests will run against the mock API server soon. In the mean time I am ignoring these, to avoid false positives.

Additionally, my IDE insisted on dome formatting changes haha