### PR TITLE
Serial cmd fixes

### DIFF
--- a/spec-serial.json
+++ b/spec-serial.json
@@ -9525,7 +9525,8 @@
         "title": "A name unique within the parent collection",
         "description": "Names must begin with a lower case ASCII letter, be composed exclusively of lowercase ASCII, uppercase ASCII, numbers, and '-', and may not end with a '-'. Names cannot be a UUID though they may contain a UUID.",
         "type": "string",
-        "pattern": "^(?![0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)^[a-z][a-z0-9-]*[a-zA-Z0-9]$",
+        "pattern": "^(?![0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)^[a-z][a-z0-9-]*[a-zA-Z0-9]*$",
+        "minLength": 1,
         "maxLength": 63
       },
       "NetworkInterface": {

--- a/spec.json
+++ b/spec.json
@@ -9309,7 +9309,8 @@
         "title": "A name unique within the parent collection",
         "description": "Names must begin with a lower case ASCII letter, be composed exclusively of lowercase ASCII, uppercase ASCII, numbers, and '-', and may not end with a '-'. Names cannot be a UUID though they may contain a UUID.",
         "type": "string",
-        "pattern": "^(?![0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)^[a-z][a-z0-9-]*[a-zA-Z0-9]$",
+        "pattern": "^(?![0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)^[a-z][a-z0-9-]*[a-zA-Z0-9]*$",
+        "minLength": 1,
         "maxLength": 63
       },
       "NetworkInterface": {

--- a/src/cmd_instance_serial.rs
+++ b/src/cmd_instance_serial.rs
@@ -32,6 +32,7 @@ impl super::cmd_instance::CmdInstanceSerial {
         let reqw_client = ClientBuilder::new()
             .connect_timeout(Duration::new(60, 0))
             .default_headers(headers)
+            .http1_only() // HTTP2 does not support websockets
             .build()?;
 
         let nexus_client = nexus_client::Client::new_with_client(base, reqw_client);


### PR DESCRIPTION
nexus can serve HTTP2 and reqwest will attempt to use it by default if possible but that's not compatible with the connection upgrade mechanism used for websockets.

The spec update is just a small cherry-pick from https://github.com/oxidecomputer/omicron/pull/2428